### PR TITLE
Support custom options

### DIFF
--- a/YoutubeDLSharp.Tests/OptionSetTests.cs
+++ b/YoutubeDLSharp.Tests/OptionSetTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using YoutubeDLSharp.Options;
 
@@ -57,6 +59,42 @@ namespace YoutubeDLSharp.Tests
             Assert.AreEqual("127.0.0.1:3128", opts.Proxy);
             Assert.AreEqual("~/Movies/%(title)s.%(ext)s", opts.Output);
             Assert.AreEqual("My Programs/ffmpeg.exe", opts.FfmpegLocation);
+        }
+        
+        [TestMethod]
+        public void TestCustomOptionSetFromString()
+        {
+            void AssertCustomOption(IOption option)
+            {
+                Assert.IsTrue(option.OptionStrings.Any());
+                Assert.IsTrue(option.IsCustom);
+                Assert.IsTrue(option.IsSet);
+                Assert.IsNotNull(option.ToString());
+            }
+
+            const string firstOption = "--my-option";
+            const string secondOption = "--my-valued-option";
+            string[] lines = {
+                firstOption,
+                $"{secondOption} value"
+            };
+            
+            // Assert custom options parsing from string
+            OptionSet opts = OptionSet.FromString(lines);
+            AssertCustomOption(opts.CustomOptions.First(s => s.DefaultOptionString == firstOption));
+            AssertCustomOption(opts.CustomOptions.First(s => s.DefaultOptionString == secondOption));
+
+            // Assert custom options cloning
+            var cloned = opts.OverrideOptions(new OptionSet());
+            AssertCustomOption(cloned.CustomOptions.First(s => s.DefaultOptionString == firstOption));
+            AssertCustomOption(cloned.CustomOptions.First(s => s.DefaultOptionString == secondOption));
+            
+            // Assert custom options override
+            var overrideOpts = opts.OverrideOptions(OptionSet.FromString(new[] { firstOption }));
+            CollectionAssert.AllItemsAreUnique(overrideOpts.CustomOptions);
+            
+            // Assert custom options to string conversion
+            Assert.IsFalse(string.IsNullOrWhiteSpace(opts.ToString()));
         }
 
         [TestMethod]

--- a/YoutubeDLSharp/Options/IOption.cs
+++ b/YoutubeDLSharp/Options/IOption.cs
@@ -1,11 +1,9 @@
-﻿using System;
-
-namespace YoutubeDLSharp.Options
+﻿namespace YoutubeDLSharp.Options
 {
     /// <summary>
     /// Interface for one youtube-dl option.
     /// </summary>
-    interface IOption
+    public interface IOption
     {
         /// <summary>
         /// The default string representation of the option flag.
@@ -24,5 +22,10 @@ namespace YoutubeDLSharp.Options
         /// </summary>
         /// <param name="s">The string (including the option flag).</param>
         void SetFromString(string s);
+
+        /// <summary>
+        /// True if this option is custom.
+        /// </summary>
+        bool IsCustom { get; }
     }
 }

--- a/YoutubeDLSharp/Options/Option.cs
+++ b/YoutubeDLSharp/Options/Option.cs
@@ -41,6 +41,11 @@ namespace YoutubeDLSharp.Options
                 this.value = value;
             }
         }
+        
+        /// <summary>
+        /// True if this option is custom.
+        /// </summary>
+        public bool IsCustom { get; }
 
         /// <summary>
         /// Creates a new instance of class Option.
@@ -49,6 +54,13 @@ namespace YoutubeDLSharp.Options
         {
             OptionStrings = optionStrings;
             IsSet = false;
+        }
+
+        public Option(bool isCustom, params string[] optionStrings)
+        {
+            OptionStrings = optionStrings;
+            IsSet = false;
+            IsCustom = isCustom;
         }
 
         /// <summary>

--- a/YoutubeDLSharp/Options/OptionComparer.cs
+++ b/YoutubeDLSharp/Options/OptionComparer.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+namespace YoutubeDLSharp.Options
+{
+    internal class OptionComparer : IEqualityComparer<IOption> 
+    {
+        public bool Equals(IOption x, IOption y)
+        {
+            if (x != null)
+            {
+                return y != null && x.ToString().Equals(y.ToString());
+            }
+            
+            return y == null;
+        }
+
+        public int GetHashCode(IOption obj) => obj.ToString().GetHashCode();
+    }
+}

--- a/YoutubeDLSharp/Options/OptionSet.Custom.cs
+++ b/YoutubeDLSharp/Options/OptionSet.Custom.cs
@@ -1,0 +1,7 @@
+﻿namespace YoutubeDLSharp.Options
+{
+    public partial class OptionSet
+    {
+        public IOption[] CustomOptions { get; set; } = new IOption[0];
+    }
+}


### PR DESCRIPTION
Following #4, this PR implements the support of passing custom `IOption`s to YoutubeDl.

This PR includes the following changes:
- [x] `IOption` is now public and has the `bool IsCustom { get; }` property.
- [x] `Option` includes an overload constructor which takes `bool isCustom` as an argument.
- [x] `OptionSet.Custom.cs` adds the `IOption[] CustomOptions { get; set; }` property to `OptionSet`.
- [x] `OptionSet.GetOptionFlags` includes the custom options.
- [x] `OptionSet.GetOptions` has been renamed to `GetKnownOptions`.
- [x] `OptionSet.OverrideOptions` combines the custom options of both old and new `OptionSet` using a custom `IOption` comparer (`OptionComparer`) which uses string comparison.
- [x] `OptionSet.FromString` parses unknown options as custom options.
If the option contains a value (for example: `"--my-option value"`) it is considered an `IOption<string>`.
If not (for example: `"--my-option"`), it is considered an `IOption<bool>`.