### PR TITLE
Add a second "RunWithOptions" Method that returns the standard RunResult<string> and accepts IProgress parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ For more about the features of youtube-dl, supported websites and anything else,
 
 ## How do I use it?
 
-First, add the package from NuGet:
 
-```
-PM> Install-Package YoutubeDLSharp
-```
+To install - check [Releases](https://github.com/adanvdo/YoutubeDLSharp/releases) for package files and add YoutubeDLSharp.DLL and Xabe.Ffmpeg.DLL to your project references
+To avoid conflicts with bluegrams, this project will not be published to nuget
 
 Now, there are two ways to use YoutubeDLSharp: the class `YoutubeDL` provides high level methods for downloading and converting videos
 while the class `YoutubeDLProcess` allows directer and flexibler access to the youtube-dl process.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # YoutubeDLSharp
 
-[![Build status](https://bluegrams.visualstudio.com/vividl/_apis/build/status/youtubedlsharp-ci)](https://bluegrams.visualstudio.com/vividl/_build/latest?definitionId=3)
-[![NuGet](https://img.shields.io/nuget/v/YoutubeDLSharp.svg)](https://www.nuget.org/packages/YoutubeDLSharp/)
+**A Modified Version of Bluegrams/YoutubeDLSharp**
 
 A simple .NET wrapper library for [youtube-dl](https://github.com/ytdl-org/youtube-dl).
+
+## adanvdo vs bluegrams - what's the difference?
+
+This repo has been modified based on use with [yt-dlp](https://github.com/yt-dlp/yt-dlp)  
+99% of the code is identical to bluegrams, with the following differences.
+
+- Target Framework Updated to .NET 4.8
+- Added Ffmpeg wrapper [Xabe.FFmpeg](https://github.com/tomaszzmuda/Xabe.FFmpeg) 
+- Added Progress Reporting Support to `RunVideoDataFetch` and `RunWithOptions`
+- Added a Second `RunWithOptions` that returns a `RunResult<string>` object instead of `RunResult<string[]>`
+- Added fallback to ffmpeg for formats missing valid metadata
 
 ## What is it?
 
@@ -74,6 +84,28 @@ As youtube-dl also allows you to extract extensive metadata for videos, you can 
 
 ```csharp
 var res = await ytdl.RunVideoDataFetch("https://www.youtube.com/watch?v=_QdPW8JrYzQ");
+// get some video information
+VideoData video = res.Data;
+string title = video.Title;
+string uploader = video.Uploader;
+long? views = video.ViewCount;
+// all available download formats
+FormatData[] formats = video.Formats;
+// ...
+```
+
+Sometimes youtube-dl / yt-dlp can return incomplete metadata.  You can set `RunVideoDataFetch` to fall-back to ffmpeg to obtain missing metadata information.
+
+```csharp
+/// <param name="url">The video URL passed to youtube-dl.</param>
+/// <param name="ct">A CancellationToken used to cancel the process.</param>
+/// <param name="flat">If set to true, does not extract information for each video in a playlist.</param>
+/// <param name="overrideOptions">Override options of the default option set for this run.</param>
+/// <param name="progress">A progress provider used to get download progress information.</param>
+/// <param name="output">A progress provider used to capture the standard output.</param>
+/// <param name="useFfmpegMetaDataFallback">If set to true, Ffmpeg will be used to fetch missing metadata values</param>
+/// <returns>A RunResult object containing a VideoData object with the requested video information.</returns>
+var res = await ytdl.RunVideoDataFetch("https://www.youtube.com/watch?v=_QdPW8JrYzQ", default, true, null, null, null, true);
 // get some video information
 VideoData video = res.Data;
 string title = video.Title;

--- a/WpfDemoApp/MainWindow.xaml.cs
+++ b/WpfDemoApp/MainWindow.xaml.cs
@@ -18,7 +18,7 @@ namespace WpfDemoApp
 
         public MainWindow()
         {
-            this.YoutubeDL = new YoutubeDL() { YoutubeDLPath = "yt-dlp.exe" };
+            this.YoutubeDL = new YoutubeDL(4, @".\Exe\yt-dlp.exe", @".\Exe");
             this.DataContext = this;
             InitializeComponent();
             progress = new Progress<DownloadProgress>((p) => showProgress(p));
@@ -91,7 +91,7 @@ namespace WpfDemoApp
         private async void InformationButton_Click(object sender, RoutedEventArgs e)
         {
             string url = txtUrl.Text;
-            RunResult<VideoData> result = await YoutubeDL.RunVideoDataFetch(url);
+            RunResult<VideoData> result = await YoutubeDL.RunVideoDataFetch(url, default, true, null, null, null, true);
             if (result.Success)
             {
                 var infoWindow = new InformationWindow(result.Data);

--- a/WpfDemoApp/WpfDemoApp.csproj
+++ b/WpfDemoApp/WpfDemoApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>
@@ -13,5 +13,16 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Exe\ffmpeg.exe">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Exe\ffprobe.exe">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Exe\yt-dlp.exe">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/YoutubeDLSharp.Tests/YoutubeDLSharp.Tests.csproj
+++ b/YoutubeDLSharp.Tests/YoutubeDLSharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/YoutubeDLSharp/Helpers/ProcessRunner.cs
+++ b/YoutubeDLSharp/Helpers/ProcessRunner.cs
@@ -23,13 +23,14 @@ namespace YoutubeDLSharp.Helpers
         }
 
         public async Task<(int, string[])> RunThrottled(YoutubeDLProcess process, string[] urls, OptionSet options,
-                                       CancellationToken ct, IProgress<DownloadProgress> progress = null)
+                                       CancellationToken ct, IProgress<DownloadProgress> progress = null, IProgress<string> output = null)
         {
             var errors = new List<string>();
             process.ErrorReceived += (o, e) => errors.Add(e.Data);
             await semaphore.WaitAsync(ct);
             try
             {
+                output?.Report($"Arguments: {process.ConvertToArgs(urls, options)}\n");
                 var exitCode = await process.RunAsync(urls, options, ct, progress);
                 return (exitCode, errors.ToArray());
             }

--- a/YoutubeDLSharp/Helpers/ProcessRunner.cs
+++ b/YoutubeDLSharp/Helpers/ProcessRunner.cs
@@ -22,15 +22,18 @@ namespace YoutubeDLSharp.Helpers
             TotalCount = initialCount;
         }
 
-        public async Task<(int, string[])> RunThrottled(YoutubeDLProcess process, string[] urls, OptionSet options,
-                                       CancellationToken ct, IProgress<DownloadProgress> progress = null, IProgress<string> output = null)
+        public async Task<(int, string[])> RunThrottled(YoutubeDLProcess process, string[] urls, OptionSet options, CancellationToken ct, 
+            IProgress<DownloadProgress> progress = null, IProgress<string> output = null, bool showArgs = true)
         {
             var errors = new List<string>();
             process.ErrorReceived += (o, e) => errors.Add(e.Data);
             await semaphore.WaitAsync(ct);
             try
             {
-                output?.Report($"Arguments: {process.ConvertToArgs(urls, options)}\n");
+                if (showArgs)
+                    output?.Report($"Arguments: {process.ConvertToArgs(urls, options)}\n");
+                else
+                    output?.Report($"Starting Download Process: {string.Join(", ", urls)}");
                 var exitCode = await process.RunAsync(urls, options, ct, progress);
                 return (exitCode, errors.ToArray());
             }

--- a/YoutubeDLSharp/Metadata/FormatData.cs
+++ b/YoutubeDLSharp/Metadata/FormatData.cs
@@ -65,6 +65,8 @@ namespace YoutubeDLSharp.Metadata
         public float? StretchedRatio { get; set; }
         [JsonProperty("no_resume")]
         public bool? NoResume { get; set; }
+        [JsonProperty("duration")]
+        public float? Duration { get; set; }
 
         public override string ToString() => $"[{Extension}] {Format}";
     }

--- a/YoutubeDLSharp/YoutubeDL.cs
+++ b/YoutubeDLSharp/YoutubeDL.cs
@@ -138,11 +138,14 @@ namespace YoutubeDLSharp
         /// <param name="output">A progress provider used to capture the standard output.</param>
         /// <returns>A RunResult object containing the path to the downloaded and converted video.</returns>
         public async Task<RunResult<string>> RunWithOptions(string url, OptionSet options, CancellationToken ct = default, 
-            IProgress<DownloadProgress> progress = null, IProgress<string> output = null)
+            IProgress<DownloadProgress> progress = null, IProgress<string> output = null, bool showArgs = true)
         {
             string outFile = string.Empty;
             var process = new YoutubeDLProcess(YoutubeDLPath);
-            output?.Report($"Arguments: {process.ConvertToArgs(new[] { url }, options)}\n");
+            if (showArgs)
+                output?.Report($"Arguments: {process.ConvertToArgs(new[] { url }, options)}\n");
+            else
+                output?.Report($"Starting Download: {url}");
             process.OutputReceived += (o, e) =>
             {
                 var match = rgxFilePostProc.Match(e.Data);
@@ -313,13 +316,14 @@ namespace YoutubeDLSharp
         /// <param name="progress">A progress provider used to get download progress information.</param>
         /// <param name="output">A progress provider used to capture the standard output.</param>
         /// <param name="overrideOptions">Override options of the default option set for this run.</param>
+        /// <param name="outputArgs">Passes full argument list to output when true</param>
         /// <returns>A RunResult object containing the path to the downloaded and converted video.</returns>
         public async Task<RunResult<string>> RunVideoDownload(string url,
             string format = "bestvideo+bestaudio/best",
             DownloadMergeFormat mergeFormat = DownloadMergeFormat.Unspecified,
             VideoRecodeFormat recodeFormat = VideoRecodeFormat.None,
             CancellationToken ct = default, IProgress<DownloadProgress> progress = null,
-            IProgress<string> output = null, OptionSet overrideOptions = null)
+            IProgress<string> output = null, OptionSet overrideOptions = null, bool outputArgs = true)
         {
             var opts = GetDownloadOptions();
             if (overrideOptions != null)
@@ -332,7 +336,10 @@ namespace YoutubeDLSharp
             string outputFile = String.Empty;
             var process = new YoutubeDLProcess(YoutubeDLPath);
             // Report the used ytdl args
-            output?.Report($"Arguments: {process.ConvertToArgs(new[] { url }, opts)}\n");
+            if (outputArgs)
+                output?.Report($"Arguments: {process.ConvertToArgs(new[] { url }, opts)}\n");
+            else
+                output?.Report($"Starting Download: {url}");
             process.OutputReceived += (o, e) =>
             {
                 var match = rgxFile.Match(e.Data);
@@ -367,7 +374,7 @@ namespace YoutubeDLSharp
             string format = "bestvideo+bestaudio/best",
             VideoRecodeFormat recodeFormat = VideoRecodeFormat.None,
             CancellationToken ct = default, IProgress<DownloadProgress> progress = null,
-            IProgress<string> output = null, OptionSet overrideOptions = null)
+            IProgress<string> output = null, OptionSet overrideOptions = null, bool outputArgs = true)
         {
             var opts = GetDownloadOptions();
             if (overrideOptions != null)
@@ -384,7 +391,10 @@ namespace YoutubeDLSharp
             var outputFiles = new List<string>();
             var process = new YoutubeDLProcess(YoutubeDLPath);
             // Report the used ytdl args
-            output?.Report($"Arguments: {process.ConvertToArgs(new[] { url }, opts)}\n");
+            if (outputArgs)
+                output?.Report($"Arguments: {process.ConvertToArgs(new[] { url }, opts)}\n");
+            else
+                output?.Report($"Starting Download: {url}");
             process.OutputReceived += (o, e) =>
             {
                 var match = rgxFile.Match(e.Data);
@@ -412,7 +422,7 @@ namespace YoutubeDLSharp
         /// <returns>A RunResult object containing the path to the downloaded and converted video.</returns>
         public async Task<RunResult<string>> RunAudioDownload(string url, AudioConversionFormat format,
             CancellationToken ct = default, IProgress<DownloadProgress> progress = null,
-            IProgress<string> output = null, OptionSet overrideOptions = null)
+            IProgress<string> output = null, OptionSet overrideOptions = null, bool outputArgs = true)
         {
             var opts = GetDownloadOptions();
             if (overrideOptions != null)
@@ -426,7 +436,10 @@ namespace YoutubeDLSharp
             var error = new List<string>();
             var process = new YoutubeDLProcess(YoutubeDLPath);
             // Report the used ytdl args
-            output?.Report($"Arguments: {process.ConvertToArgs(new[] { url }, opts)}\n");
+            if (outputArgs)
+                output?.Report($"Arguments: {process.ConvertToArgs(new[] { url }, opts)}\n");
+            else
+                output?.Report($"Starting Download: {url}");
             process.OutputReceived += (o, e) =>
             {
                 var match = rgxFile.Match(e.Data);
@@ -458,7 +471,7 @@ namespace YoutubeDLSharp
             int? start = 1, int? end = null,
             int[] items = null, AudioConversionFormat format = AudioConversionFormat.Best,
             CancellationToken ct = default, IProgress<DownloadProgress> progress = null,
-            IProgress<string> output = null, OptionSet overrideOptions = null)
+            IProgress<string> output = null, OptionSet overrideOptions = null, bool outputArgs = true)
         {
             var outputFiles = new List<string>();
             var opts = GetDownloadOptions();
@@ -476,7 +489,10 @@ namespace YoutubeDLSharp
             opts.AudioFormat = format;
             var process = new YoutubeDLProcess(YoutubeDLPath);
             // Report the used ytdl args
-            output?.Report($"Arguments: {process.ConvertToArgs(new[] { url }, opts)}\n");
+            if (outputArgs)
+                output?.Report($"Arguments: {process.ConvertToArgs(new[] { url }, opts)}\n");
+            else
+                output?.Report($"Starting Download: {url}");
             process.OutputReceived += (o, e) =>
             {
                 var match = rgxFile.Match(e.Data);

--- a/YoutubeDLSharp/YoutubeDL.cs
+++ b/YoutubeDLSharp/YoutubeDL.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ using Newtonsoft.Json;
 using YoutubeDLSharp.Helpers;
 using YoutubeDLSharp.Metadata;
 using YoutubeDLSharp.Options;
+using Xabe.FFmpeg;
 
 namespace YoutubeDLSharp
 {
@@ -26,10 +28,31 @@ namespace YoutubeDLSharp
         /// Path to the youtube-dl executable.
         /// </summary>
         public string YoutubeDLPath { get; set; } = "youtube-dl.exe";
+
+        private string ffmpegPath = "ffmpeg.exe";
         /// <summary>
         /// Path to the FFmpeg executable.
         /// </summary>
-        public string FFmpegPath { get; set; } = "ffmpeg.exe";
+        public string FFmpegPath 
+        {        
+            get { return ffmpegPath; }
+            set { ffmpegPath = value; }
+        }
+
+        private string ffmpegExecutablesPath = "";
+        /// <summary>
+        /// Path to FFmpeg and FFprobe executables
+        /// </summary>
+        public string FFmpegExecutablesPath
+        {
+            get { return ffmpegExecutablesPath; }
+            set
+            {
+                ffmpegExecutablesPath = value;
+                ffmpegPath = Path.Combine(ffmpegExecutablesPath, "ffmpeg.exe");
+                FFmpeg.SetExecutablesPath(ffmpegExecutablesPath);
+            }
+        }
         /// <summary>
         /// Path of the folder where items will be downloaded to.
         /// </summary>
@@ -66,9 +89,15 @@ namespace YoutubeDLSharp
         /// Creates a new instance of the YoutubeDL class.
         /// </summary>
         /// <param name="maxNumberOfProcesses">The maximum number of concurrent youtube-dl processes.</param>
-        public YoutubeDL(byte maxNumberOfProcesses = 4)
+        /// <param name="ytdlPath">The path to youtube-dl.exe</param>
+        /// <param name="ffmpegExecutablesPath">The path to the directory where ffmpeg executables are located</param>
+        public YoutubeDL(byte maxNumberOfProcesses = 4, string ytdlPath = "", string ffmpegExecutablesPath = "")
         {
             runner = new ProcessRunner(maxNumberOfProcesses);
+            if (!string.IsNullOrEmpty(ytdlPath))
+                YoutubeDLPath = ytdlPath;
+            if (!string.IsNullOrEmpty(ffmpegExecutablesPath))
+                FFmpegExecutablesPath = ffmpegExecutablesPath;
         }
 
         /// <summary>
@@ -86,14 +115,17 @@ namespace YoutubeDLSharp
         /// <param name="urls">The video URLs passed to youtube-dl.</param>
         /// <param name="options">The OptionSet of youtube-dl options.</param>
         /// <param name="ct">A CancellationToken used to cancel the process.</param>
+        /// <param name="progress">A progress provider used to get download progress information.</param>
+        /// <param name="output">A progress provider used to capture the standard output.</param>
         /// <returns>A RunResult object containing the output of youtube-dl as an array of string.</returns>
-        public async Task<RunResult<string[]>> RunWithOptions(string[] urls, OptionSet options, CancellationToken ct)
+        public async Task<RunResult<string[]>> RunWithOptions(string[] urls, OptionSet options, CancellationToken ct,
+            IProgress<DownloadProgress> progress = null, IProgress<string> output = null)
         {
-            var output = new List<string>();
+            var outputList = new List<string>();
             var process = new YoutubeDLProcess(YoutubeDLPath);
-            process.OutputReceived += (o, e) => output.Add(e.Data);
-            (int code, string[] errors) = await runner.RunThrottled(process, urls, options, ct);
-            return new RunResult<string[]>(code == 0, errors, output.ToArray());
+            process.OutputReceived += (o, e) => outputList.Add(e.Data);
+            (int code, string[] errors) = await runner.RunThrottled(process, urls, options, ct, progress, output);
+            return new RunResult<string[]>(code == 0, errors, outputList.ToArray());
         }
 
         /// <summary>
@@ -104,7 +136,6 @@ namespace YoutubeDLSharp
         /// <param name="ct">A CancellationToken used to cancel the process.</param>
         /// <param name="progress">A progress provider used to get download progress information.</param>
         /// <param name="output">A progress provider used to capture the standard output.</param>
-        /// <param name="overrideOptions">Override options of the default option set for this run.</param>
         /// <returns>A RunResult object containing the path to the downloaded and converted video.</returns>
         public async Task<RunResult<string>> RunWithOptions(string url, OptionSet options, CancellationToken ct = default, 
             IProgress<DownloadProgress> progress = null, IProgress<string> output = null)
@@ -146,9 +177,13 @@ namespace YoutubeDLSharp
         /// <param name="ct">A CancellationToken used to cancel the process.</param>
         /// <param name="flat">If set to true, does not extract information for each video in a playlist.</param>
         /// <param name="overrideOptions">Override options of the default option set for this run.</param>
+        /// <param name="progress">A progress provider used to get download progress information.</param>
+        /// <param name="output">A progress provider used to capture the standard output.</param>
+        /// <param name="useFfmpegMetaDataFallback">If set to true, Ffmpeg will be used to fetch missing metadata values</param>
         /// <returns>A RunResult object containing a VideoData object with the requested video information.</returns>
         public async Task<RunResult<VideoData>> RunVideoDataFetch(string url,
-            CancellationToken ct = default, bool flat = true, OptionSet overrideOptions = null)
+            CancellationToken ct = default, bool flat = true, OptionSet overrideOptions = null,
+            IProgress<DownloadProgress> progress = null, IProgress<string> output = null, bool useFfmpegMetaDataFallback = false)
         {
             var opts = GetDownloadOptions();
             if (overrideOptions != null)
@@ -160,8 +195,111 @@ namespace YoutubeDLSharp
             VideoData videoData = null;
             var process = new YoutubeDLProcess(YoutubeDLPath);
             process.OutputReceived += (o, e) => videoData = JsonConvert.DeserializeObject<VideoData>(e.Data);
-            (int code, string[] errors) = await runner.RunThrottled(process, new[] { url }, opts, ct);
+            (int code, string[] errors) = await runner.RunThrottled(process, new[] { url }, opts, ct, progress, output);
+            if (code == 0 && useFfmpegMetaDataFallback)
+            {
+                if (videoData.Formats == null && videoData.Entries != null)
+                {
+                    List<FormatData> entryFormats = new List<FormatData>();
+                    for(int i = videoData.Entries.Length - 1; i >= 0; i--)
+                    {
+                        VideoData child = videoData.Entries[i];
+                        if (child.Formats == null)
+                        {
+                            entryFormats.Add(new FormatData()
+                            {
+                                Url = child.Url,
+                                Format = child.Format,
+                                Extension = child.Extension
+                            });
+                        }
+                        else
+                        {
+                            entryFormats.AddRange(videoData.Entries[i].Formats);
+                        }
+                    }
+
+                    var processed = await executeFallback(entryFormats.Distinct().ToArray(), output);
+                    videoData.Formats = processed.ToArray();
+                    if (videoData.Duration == null)
+                    {
+                        var first = videoData.Formats.First(f => f.Duration != null);
+                        if (first != null)
+                            videoData.Duration = first.Duration;
+                    }
+                }
+                else if(videoData.Formats != null && videoData.Formats.Length > 0)
+                {
+                    videoData.Formats = await executeFallback(videoData.Formats, output);
+                    if (videoData.Duration == null) {
+                        var first = videoData.Formats.First(f => f.Duration != null);
+                        if (first != null)
+                            videoData.Duration = first.Duration;
+                    }
+                }
+
+            }
             return new RunResult<VideoData>(code == 0, errors, videoData);
+        }
+
+        private async Task<FormatData[]> executeFallback(FormatData[] formats, IProgress<string> output = null)
+        {
+            if (formats != null && formats.Length > 0 && formats.Where(f => f.VideoCodec == null && f.AudioCodec == null).Count() > 0)
+            {
+                if (string.IsNullOrEmpty(FFmpeg.ExecutablesPath))
+                    throw new Exception("Ffmpeg Executables Path Not Defined");
+                
+                    int item = 0;
+                    output?.Report($"MetaData Incomplete - Analyzing [{item}/{formats.Length}]");
+                foreach (var format in formats)
+                {
+                    item++;
+                    output?.Report($"MetaData Incomplete - Analyzing [{item}/{formats.Length}]");
+                    if (format.VideoCodec == null && format.AudioCodec == null)
+                    {
+                        float? dur = null;
+                        var fInfo = await FFmpeg.GetMediaInfo(format.Url);
+                        if (fInfo != null)
+                        {
+                            if (fInfo.Duration != null)
+                                dur = (float?)fInfo.Duration.TotalSeconds;
+                            format.FileSize = (long?)fInfo.Size;
+                            if (fInfo.VideoStreams != null && fInfo.VideoStreams.Count() > 0)
+                            {
+                                var vid = fInfo.VideoStreams.First();
+                                if (vid != null)
+                                {
+                                    format.Bitrate = (double?)vid.Bitrate;
+                                    format.VideoCodec = vid.Codec;
+                                    format.Width = (int?)vid.Width;
+                                    format.Height = (int?)vid.Height;
+                                    format.VideoBitrate = (double?)vid.Bitrate;
+                                    format.FrameRate = (float?)vid.Framerate;
+                                }
+                            }
+                            if (fInfo.AudioStreams != null && fInfo.AudioStreams.Count() > 0)
+                            {
+                                var aud = fInfo.AudioStreams.First();
+                                if (aud != null)
+                                {
+                                    if (dur == null && aud.Duration != null)
+                                        dur = (float?)aud.Duration.TotalSeconds;
+                                    format.AudioCodec = aud.Codec;
+                                    format.AudioBitrate = (double?)aud.Bitrate;
+                                    format.AudioSamplingRate = (double?)aud.SampleRate;
+                                }
+                            }
+                            else
+                            {
+                                format.AudioCodec = "none";
+                            }
+                        }
+                        if (format.Duration == null)
+                            format.Duration = dur;
+                    }
+                }                
+            }
+            return formats;
         }
 
         /// <summary>

--- a/YoutubeDLSharp/YoutubeDL.cs
+++ b/YoutubeDLSharp/YoutubeDL.cs
@@ -255,7 +255,7 @@ namespace YoutubeDLSharp
                 {
                     item++;
                     output?.Report($"MetaData Incomplete - Analyzing [{item}/{formats.Length}]");
-                    if (format.VideoCodec == null && format.AudioCodec == null)
+                    if ((format.VideoCodec == null || format.VideoCodec == "none") && (format.AudioCodec == null || format.AudioCodec == "none"))
                     {
                         float? dur = null;
                         var fInfo = await FFmpeg.GetMediaInfo(format.Url);

--- a/YoutubeDLSharp/YoutubeDLProcess.cs
+++ b/YoutubeDLSharp/YoutubeDLProcess.cs
@@ -175,7 +175,7 @@ namespace YoutubeDLSharp
                 catch { }
             });
             Debug.WriteLine("[youtube-dl] Arguments: " + process.StartInfo.Arguments);
-            if (!process.Start())
+            if (!await Task.Run(() => process.Start()))
                 tcs.TrySetException(new InvalidOperationException("Failed to start youtube-dl process."));
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();

--- a/YoutubeDLSharp/YoutubeDLSharp.csproj
+++ b/YoutubeDLSharp/YoutubeDLSharp.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net4.8</TargetFrameworks>
-    <Authors>Bluegrams</Authors>
+    <Authors>Bluegrams, adanvdo</Authors>
     <Description>A simple .NET wrapper library for youtube-dl.</Description>
-    <Copyright>© 2022 Bluegrams</Copyright>
+    <Copyright>© 2022 Bluegrams, adanvdo</Copyright>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/Bluegrams/YoutubeDLSharp</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/adanvdo/YoutubeDLSharp</PackageProjectUrl>
     <PackageTags>youtube video download youtube-dl yt-dlp</PackageTags>
     <LangVersion>7.3</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -18,7 +18,7 @@
     <BuildYear>$([System.DateTime]::Now.ToString(yy))</BuildYear>
     <BuildDay>$([System.DateTime]::Now.DayOfYear)</BuildDay>
     <AssemblyVersion>$(VersionPrefix).$(BuildYear)$(BuildDay)</AssemblyVersion>
-    <PackageReleaseNotes>https://github.com/Bluegrams/YoutubeDLSharp/blob/master/Changelog.md</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/adanvdo/YoutubeDLSharp/blob/master/Changelog.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/YoutubeDLSharp/YoutubeDLSharp.csproj
+++ b/YoutubeDLSharp/YoutubeDLSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net4.8</TargetFrameworks>
     <Authors>Bluegrams</Authors>
     <Description>A simple .NET wrapper library for youtube-dl.</Description>
     <Copyright>© 2022 Bluegrams</Copyright>
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Xabe.FFmpeg" Version="5.2.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
I was needing to do some post-processing on audio-only formats and the `RunAudioDownload` method was not able to do what I needed.  `RunWithOptions` was able to do it, but I ran into a couple things that were problematic in my project.
- RunWithOptions did not accept the standard string url param the other download methods do
- It did not accept the Progress or Output IProgress params. 
- It did not return a clean Download Location

This change implements a second `RunWithOptions` method that accepts the standard parameters used by the other download methods and returns a clean Download Location.