### PR TITLE
Updated RunAudioDownload to fix default parameter

### DIFF
--- a/YoutubeDLSharp/YoutubeDL.cs
+++ b/YoutubeDLSharp/YoutubeDL.cs
@@ -241,7 +241,7 @@ namespace YoutubeDLSharp
         /// <param name="output">A progress provider used to capture the standard output.</param>
         /// <param name="overrideOptions">Override options of the default option set for this run.</param>
         /// <returns>A RunResult object containing the path to the downloaded and converted video.</returns>
-        public async Task<RunResult<string>> RunAudioDownload(string url, AudioConversionFormat format,
+        public async Task<RunResult<string>> RunAudioDownload(string url, AudioConversionFormat format = AudioConversionFormat.Best,
             CancellationToken ct = default, IProgress<DownloadProgress> progress = null,
             IProgress<string> output = null, OptionSet overrideOptions = null)
         {


### PR DESCRIPTION
Made the AudioConversionFormat set to a default of Best
This makes the RunAudioDownload in line with all of the other download functions, with the url being the only required parameter, and the rest being default/optional.