### PR TITLE
Add a second "RunWithOptions" Method that returns the standard RunResult<string> and accepts IProgress parameters

### DIFF
--- a/YoutubeDLSharp/YoutubeDL.cs
+++ b/YoutubeDLSharp/YoutubeDL.cs
@@ -18,6 +18,7 @@ namespace YoutubeDLSharp
     public class YoutubeDL
     {
         private static readonly Regex rgxFile = new Regex(@"^outfile:\s\""?(.*)\""?", RegexOptions.Compiled);
+        private static Regex rgxFilePostProc = new Regex(@"\[download\] Destination: [a-zA-Z]:\\\S+\.\S{3,}", RegexOptions.Compiled);
 
         protected ProcessRunner runner;
 
@@ -89,6 +90,39 @@ namespace YoutubeDLSharp
             process.OutputReceived += (o, e) => output.Add(e.Data);
             (int code, string[] errors) = await runner.RunThrottled(process, urls, options, ct);
             return new RunResult<string[]>(code == 0, errors, output.ToArray());
+        }
+
+        /// <summary>
+        /// Runs youtube-dl with the given option set and additional parameters.
+        /// </summary>
+        /// <param name="url">The video URL passed to youtube-dl.</param>
+        /// <param name="options">The OptionSet of youtube-dl options.</param>
+        /// <param name="ct">A CancellationToken used to cancel the process.</param>
+        /// <param name="progress">A progress provider used to get download progress information.</param>
+        /// <param name="output">A progress provider used to capture the standard output.</param>
+        /// <param name="showArgs">When true, outputs full download arguments</param>
+        /// <returns>A RunResult object containing the path to the downloaded and converted video.</returns>
+        public async Task<RunResult<string>> RunWithOptions(string url, OptionSet options, CancellationToken ct = default,
+            IProgress<DownloadProgress> progress = null, IProgress<string> output = null, bool showArgs = true)
+        {
+            string outFile = string.Empty;
+            var process = new YoutubeDLProcess(YoutubeDLPath);
+            if (showArgs)
+                output?.Report($"Arguments: {process.ConvertToArgs(new[] { url }, options)}\n");
+            else
+                output?.Report($"Starting Download: {url}");
+            process.OutputReceived += (o, e) =>
+            {
+                var match = rgxFilePostProc.Match(e.Data);
+                if (match.Success)
+                {
+                    outFile = match.Groups[0].ToString().Replace("[download] Destination:", "").Replace(" ", "");
+                    progress?.Report(new DownloadProgress(DownloadState.Success, data: outFile));
+                }
+                output?.Report(e.Data);
+            };
+            (int code, string[] errors) = await runner.RunThrottled(process, new[] { url }, options, ct, progress);
+            return new RunResult<string>(code == 0, errors, outFile);
         }
 
         /// <summary>


### PR DESCRIPTION
This is a cleaned up implementation of the PR I put up a while back.

I was needing to do some post-processing on audio-only formats and the RunAudioDownload method was not able to do what I needed. RunWithOptions was able to do it, but I ran into a couple things that were problematic in my project.

- RunWithOptions did not accept the standard string url param the other download methods do
- It did not accept the Progress or Output IProgress params.
- It did not return a clean Download Location

This change implements a second RunWithOptions method that accepts the standard parameters used by the other download methods and returns a clean Download Location.