### PR TITLE
Fix bad parsing

### DIFF
--- a/YoutubeDLSharp.Tests/MetadataTests.cs
+++ b/YoutubeDLSharp.Tests/MetadataTests.cs
@@ -34,6 +34,21 @@ namespace YoutubeDLSharp.Tests
         }
 
         [TestMethod]
+        public async Task TestVideoInformationYoutube_Premier()
+        {
+            string url = "https://youtu.be/HEdbxIfAKyk";
+            RunResult<VideoData> result = await ydl.RunVideoDataFetch(url);
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(MetadataType.Video, result.Data.ResultType);
+            Assert.AreEqual("TEST VIDEO PREMIER", result.Data.Title);
+            Assert.AreEqual("Youtube", result.Data.ExtractorKey);
+            Assert.AreEqual(new DateTime(2020, 11, 25), result.Data.UploadDate);
+            Assert.IsNotNull(result.Data.Formats);
+            Assert.IsNotNull(result.Data.Tags);
+            Assert.IsNull(result.Data.Entries);
+        }
+        
+        [TestMethod]
         public async Task TestPlaylistInformation()
         {
             string url = "https://www.youtube.com/playlist?list=PLD8804CB40CAB0EA5";

--- a/YoutubeDLSharp/Converters/DateTimeConverter.cs
+++ b/YoutubeDLSharp/Converters/DateTimeConverter.cs
@@ -13,17 +13,15 @@ namespace YoutubeDLSharp.Converters
         private readonly DateTime _Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         public override DateTime? ReadJson(JsonReader reader, Type objectType, DateTime? existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            if(reader.Value == null)
+            if (reader.Value == null)
             {
                 return null;
             }
-            else
-            {
-                var value = (double)reader.Value;
-                var timeSpan = TimeSpan.FromSeconds(value);
-                var utc = _Epoch.Add(timeSpan).ToUniversalTime();
-                return utc;
-            }
+
+            var value = Convert.ToDouble(reader.Value);
+            var timeSpan = TimeSpan.FromSeconds(value);
+            var utc = _Epoch.Add(timeSpan).ToUniversalTime();
+            return utc;
         }
 
         public override void WriteJson(JsonWriter writer, DateTime? value, JsonSerializer serializer)


### PR DESCRIPTION
Fix #30 by replacing a cast to a `Convert.ToDouble()` call.

This error only seems to happen when downloading the VideoData on videos that are premieres or live streams.